### PR TITLE
Expose port in docker Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -installsuffix cgo -o /go/
 FROM scratch
 COPY --from=builder /go/bin/kube-eagle /go/bin/kube-eagle
 
+EXPOSE ${TELEMETRY_PORT}
+
 ENV VERSION 1.1.3
 ENTRYPOINT ["/go/bin/kube-eagle"]


### PR DESCRIPTION
To make it possible to register the service in consul when using [Gliderlabs Registrator](https://gliderlabs.github.io/registrator/latest/user/services/#ip-and-port) running with the -internal option:

"If you use the -internal option, Registrator will use the exposed port and Docker-assigned internal IP of the container."

Relates to: https://github.com/cloudworkz/kube-eagle-helm-chart/pull/24